### PR TITLE
bugfix/correctly-display-moviesessions-table-on-admin

### DIFF
--- a/CinemaApp/DataAccess/MovieSessionAccess.cs
+++ b/CinemaApp/DataAccess/MovieSessionAccess.cs
@@ -23,12 +23,14 @@ public static class MovieSessionAccess
         {
             string sql = @"
                 SELECT
-                id AS Id,
-                movie_hall_id AS MovieHallId,
-                movie_id AS MovieId,
+                movie_session.id AS Id,
+                movie_hall.name AS MovieHallName,
+                movie.title AS MovieTitle,
                 start_time AS StartTime,
                 date AS Date
-                FROM movie_session";
+                FROM movie_session
+                INNER JOIN movie ON movie_session.id == movie.id
+                INNER JOIN movie_hall ON movie_session.id == movie_hall.id";
             return connection.Query<MovieSession>(sql).ToList();
         }
     }

--- a/CinemaApp/DataModels/MovieSession.cs
+++ b/CinemaApp/DataModels/MovieSession.cs
@@ -5,4 +5,9 @@ public class MovieSession
     public int MovieId { get; set; }
     public string StartTime { get; set; }
     public string Date { get; set; }
+
+    // INNER JOIN ticket -> Movie
+    public string MovieTitle { get; set; }
+    // INNER JOIN ticket -> MovieHall
+    public string MovieHallName { get; set; }
 }

--- a/CinemaApp/DataModels/Reservation.cs
+++ b/CinemaApp/DataModels/Reservation.cs
@@ -7,8 +7,7 @@ public class Reservation
     public string Status { get; set; }
     public string CreatedAt { get; set; }
     public double TotalPrice { get; set; }
-    public string TotalPriceString => $"€{TotalPrice:F2}";
-
+    public string TotalPriceString => $"€{TotalPrice:F2}";  
     public string MovieHall { get; set; }
     public string MovieTitle { get; set; }
     public string StartTime { get; set; }

--- a/CinemaApp/Presentation/Admin/SessionManagementScreen.cs
+++ b/CinemaApp/Presentation/Admin/SessionManagementScreen.cs
@@ -117,7 +117,7 @@ public class SessionManagementScreen : IScreen
         }
 
         var table = new Table<MovieSession>(maxColWidth: 40, pageSize: 10);
-        table.SetColumns("Id", "MovieHallId", "MovieId", "StartTime", "Date");
+        table.SetColumns("Id", "MovieHallName", "MovieTitle", "StartTime", "Date");
         table.AddRows(sessions);
 
         var movieHalls = MovieAdminLogic.GetAllMovieHalls();
@@ -131,7 +131,7 @@ public class SessionManagementScreen : IScreen
         {
             General.ClearConsole();
             Console.WriteLine("Select session to update:\n");
-            table.Print("Id", "MovieHallId", "MovieId", "StartTime", "Date");
+            table.Print("Id", "MovieHall", "Movie", "StartTime", "Date");
             Console.WriteLine("\n[↑][↓] Navigate  [←][→] Page  [ENTER] Edit  [ESC] Cancel");
 
             key = Console.ReadKey(true).Key;
@@ -214,7 +214,7 @@ public class SessionManagementScreen : IScreen
     {
         var readScreen = new ReadScreen<MovieSession>(
             MovieAdminLogic.GetAllMovieSessions,
-            new[] { "Id", "MovieHallId", "MovieId", "StartTime", "Date" });
+            new[] { "Id", "MovieHallName", "MovieTitle", "StartTime", "Date" });
 
         readScreen.Start();
     }


### PR DESCRIPTION
Bugfixes related to correctly displaying movie sessions on admin page.

Done:
- Added fields for MovieTitle & MovieHallName & made corresponding JOIN SQL query.
- View page & update page already correctly displays the movie sessions

TODO:
- Display movie sessions data correctly on delete page
- Fix other bugs related to movie sessions admin